### PR TITLE
Extract much more details

### DIFF
--- a/imgur_scraper/imgur_scraper.py
+++ b/imgur_scraper/imgur_scraper.py
@@ -121,7 +121,7 @@ def main():
         type=str,
         metavar="",
         help="date format YYYY-MM-DD (optional)",
-        default=str(datetime.utcnow()),
+        default=str(datetime.datetime.utcnow()),
     )
     parser.add_argument(
         "--csv",

--- a/imgur_scraper/imgur_scraper.py
+++ b/imgur_scraper/imgur_scraper.py
@@ -36,6 +36,20 @@ def get_more_details_of_post(post_url: str) -> json:
     matched = re.search(regex, request.html.find('script')[18].text).group(0)  # 18th script tag has the `item` dict. this is tested on more than 1500 links.
     item = json.loads(matched[5:])
 
+    details['username'] = item['account_url']
+    details['comment_count'] = item['comment_count']
+    details['downs'] = item['downs']
+    details['ups'] = item['ups']
+    details['points'] = item['points']
+    details['score'] = item['score']
+    details['timestamp'] = item['timestamp']
+    details['views'] = item['views']
+    details['favorite_count'] = item['favorite_count']
+    details['hot_datetime'] = item['hot_datetime']
+    details['nsfw'] = item['nsfw']
+    details['platform'] = item['platform']
+    details['virality'] = item['virality']
+
     return details
 
 

--- a/imgur_scraper/imgur_scraper.py
+++ b/imgur_scraper/imgur_scraper.py
@@ -1,57 +1,13 @@
 import argparse
 import csv
-# import datetime
+import datetime
 import json
 import os
 import re
 
 from requests_html import HTMLSession
 
-# from .utils import Convert
-################
-
-from datetime import datetime, date, timedelta
-
-date_format = "%Y-%m-%d"
-
-
-class Convert:
-    """Subtracts the given time from the current UTC time
-    and returns the number of days.
-
-    :param:start_date, where date is a string
-    :param:end_date, where date is a string
-    """
-
-    def __init__(self, start_date: str, end_date: str):
-        self.start_date = start_date
-        self.end_date = end_date
-
-    def _user_given_time(self):
-        return (
-            datetime.strptime(self.start_date, date_format),
-            datetime.strptime(self.end_date, date_format),
-        )
-
-    def to_days_ago(self):
-        start_time, end_time = self._user_given_time()
-        time_now = datetime.utcnow()
-        if time_now < start_time or time_now < end_time:
-            raise ValueError("Invalid Date")
-        start_time = (datetime.utcnow() - start_time).days
-        end_time = (datetime.utcnow() - end_time).days
-        if start_time < end_time:
-            raise ValueError("Invalid Date Range")
-        return start_time, end_time
-
-    def from_days_ago(self, days_ago: int):
-        date_components = list(
-            map(lambda n: int(n), self.start_date.split("-")))
-        date_ref = date(
-            date_components[0], date_components[1], date_components[2]
-        ) + timedelta(days=float(days_ago))
-        return date_ref.strftime(date_format)
-###############
+from .utils import Convert
 
 
 def get_more_details_of_post(post_url: str) -> json:
@@ -67,6 +23,7 @@ def get_more_details_of_post(post_url: str) -> json:
         if len(request.html.find('script')) < 18:
             request = HTMLSession().get(post_url)
 
+            return details
             # handle when its not there at all
 
         regex = 'item: ({.+} )'  # regex to isolate the `item` dict.


### PR DESCRIPTION
#### So here's an update @saadmanrafat. I did quite a bit of digging around and found an object within one of the script tags part of every post. I tested this with around 1500 links. 
So here's what I thought:
 - Add a flag to the CLI like `--details`, that will allow the user to get a lot more details which would take more time as we'd be making a request for every post. 
 - The reason we should consider the time trade-off is because we get a lot data like the `virality` score of a post, `nsfw` status, time when it became "hot" etc. (there are 10+ data points)
#### The JSON object I extracted can be found [here](https://gist.github.com/gaurav-kay/36dfa8d70cabc2c2c7b27eb3f5b0bcd0)